### PR TITLE
Add basic version of ai_su with cgroups script

### DIFF
--- a/lista5/ai_su_cg.sh
+++ b/lista5/ai_su_cg.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+if [[ $# -lt 1 ]]; then
+    echo $'\033[1;31mError:\033[0m  You should specify the path to directory with run.sh in it!' 
+    exit 1
+fi
+
+# problem with root for cgroups https://unix.stackexchange.com/questions/197718/does-managing-cgroups-require-root-access
+
+cpu_set=0
+
+sudo cgcreate -g cpuset,memory:ailimitgroup
+sudo cgset -r cpuset.cpus=${cpu_set} ailimitgroup              # CPU number, can be define as a set, for ex. 0-3,15 => 0,1,2,3,15
+sudo cgset -r cpuset.mems=0 ailimitgroup
+sudo cgset -r cpuset.cpu_exclusive=1 ailimitgroup
+sudo cgset -r memory.limit_in_bytes=6m ailimitgroup            # 6G => 6 GiB (gibibytes) = 6442450944 bytes
+# !!! After taking all the memory process will use SWAP, probably we need to limit both of them together example:
+# sudo cgset -r memory.memsw.limit_in_bytes=6m ailimitgroup 
+
+# cgget -a ailimitgroup  # to list configuration
+
+cd $1
+sudo cgexec -g cpuset,memory:ailimitgroup bash ./run.sh
+
+sudo cgdelete -g cpuset,memory:ailimitgroup


### PR DESCRIPTION
Dodałem wstępną wersje skryptu w bashu który odpala ./run.sh z ograniczeniami z użyciem `cgroups`.
Kilka komentarzy umieściłem w skrypcie oraz poniżej.

**Problemy:**

* nie wiem czy to `cpuset.cpu_exclusive=1` działa - nie wiem jak przetestować
* wymaga uprawnień root'a albo takiego rozwiązania (https://unix.stackexchange.com/questions/197718/does-managing-cgroups-require-root-access)
* odpala proces (od studenta) jako root (chyba nie najlepszy pomysł :wink: )

**Do zmiany:**

* `cpu_set` pewnie powinien być wczytywany jako argument i walidowany w skrypcie
* nie wiem w końcu czy dostajemy rdzeń czy wątek, to trzeba doprecyzować
* prawdopodobnie zamiast `memory.limit_in_bytes` powinnobyć `memory.memsw.limit_in_byte` bo inaczej po zużyciu całego RAMu wchodzi na SWAP (w skrypcie ustawiłem ograniczenie pamięci na 6MiB więc szybko można zauważyć jak wchodzi na SWAP - docelowo powinno być `6G`).