### PR TITLE
fixing a bug with an empty row/column?

### DIFF
--- a/lista5/ai_nonogram_validator.py
+++ b/lista5/ai_nonogram_validator.py
@@ -102,6 +102,11 @@ def count_blocks(r):
             b += 1
     if b > 0:
         ret.append(b)
+    # according to the following clarification, an empty row/column 
+    # should be represented in input as a single zero
+    # https://skos.ii.uni.wroc.pl/mod/forum/discuss.php?d=387
+    if ret == []:
+        ret = [0]
     return ret
 
 


### PR DESCRIPTION
I am pretty sure that the validator is not working in case of an empty row/column.
In `case_def` such row/column will be represented as `[0]`, meanwhile `ret_def` will contain `[]`.